### PR TITLE
remove unconditional Connect when excluding Wi-Fi networks

### DIFF
--- a/js/finalize.js
+++ b/js/finalize.js
@@ -253,10 +253,6 @@ function saveDynamicDataToFile() {
                 });
                 fileString += "</array>\n";
                 fileString += "</dict>\n";
-                fileString += "<dict>\n";
-                fileString += "<key>Action</key>\n";
-                fileString += "<string>Connect</string>\n";
-                fileString += "</dict>\n";
             }
             if (getCookie(i + "useWifi") == "true") {
                 fileString += "<dict>\n";


### PR DESCRIPTION
According to [Apple's documentation](https://developer.apple.com/documentation/networkextension/neondemandrule), the first matching rule in an `OnDemandRules` array is used:

> When rules are defined in an array, they are evaluated in order and the action of the first rule to match all conditions is chosen.

The `finalize.js` script adds these lines to the profile when the options are set to enable the DNS settings for Wi-Fi only and to exclude the SSID "example":

```xml
<dict>
<key>Action</key>
<string>Disconnect</string>
<key>SSIDMatch</key>
<array>
<string>example</string>
</array>
</dict>
<dict>
<key>Action</key>
<string>Connect</string>
</dict>
<dict>
<key>Action</key>
<string>Connect</string>
<key>InterfaceTypeMatch</key>
<string>WiFi</string>
</dict>
<dict>
<key>Action</key>
<string>Disconnect</string>
</dict>
```

Because this item...

```xml
<dict>
<key>Action</key>
<string>Connect</string>
</dict>
```

...has no condition and thus always matches, the items after it are never evaluated. This causes the DNS settings to be applied on both Wi-Fi and cellular, instead of only on Wi-Fi as was intended. I don't see any reason why this item is needed as enabling the DNS settings for other Wi-Fi networks is already covered by the item after it...

```xml
<dict>
<key>Action</key>
<string>Connect</string>
<key>InterfaceTypeMatch</key>
<string>WiFi</string>
</dict>
```

...so I think the best solution is to remove it entirely.